### PR TITLE
fix(signals): surface reacceleration signal v2 in explain

### DIFF
--- a/src/altcoin_trend/signals/explain.py
+++ b/src/altcoin_trend/signals/explain.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-
 from collections.abc import Mapping
+from collections.abc import Sequence
+
 from typing import Any
 
 
@@ -19,23 +20,59 @@ def _format_optional_float(value: Any) -> str:
         return "n/a"
 
 
+def _format_optional_int(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    try:
+        return str(int(value))
+    except (TypeError, ValueError):
+        return "n/a"
+
+
+def _format_grade(value: Any) -> str:
+    if value is None:
+        return "-"
+    text = str(value).strip()
+    return text if text else "-"
+
+
+def _format_bool(value: Any) -> str:
+    return "yes" if bool(value) else "no"
+
+
+def _normalize_items(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        normalized = value.strip()
+        return (normalized,) if normalized else ()
+    if isinstance(value, Sequence):
+        return tuple(str(item).strip() for item in value if item is not None and str(item).strip())
+    normalized = str(value).strip()
+    return (normalized,) if normalized else ()
+
+
 def build_explain_text(row: Mapping[str, Any] | Any) -> str:
     exchange = _get(row, "exchange", "unknown")
     symbol = row["symbol"] if isinstance(row, Mapping) else getattr(row, "symbol")
     final_score = _get(row, "final_score", 0.0)
     tier = _get(row, "tier", "rejected")
-    raw_veto = _get(row, "veto_reason_codes", ())
-    if raw_veto is None:
-        veto = ()
-    elif isinstance(raw_veto, str):
-        veto = (raw_veto,)
-    else:
-        veto = tuple(raw_veto)
+    veto = _normalize_items(_get(row, "veto_reason_codes", ()))
+    risk_flags = _normalize_items(_get(row, "risk_flags", ()))
 
     lines = [
         f"{exchange}:{symbol}",
         f"Score: {final_score}",
         f"Tier: {tier}",
+        "Signal v2:",
+        f"Priority: {_format_optional_int(_get(row, 'signal_priority', None))}",
+        f"Continuation: {_format_grade(_get(row, 'continuation_grade', None))}",
+        f"Ignition: {_format_grade(_get(row, 'ignition_grade', None))}",
+        f"Reacceleration: {_format_grade(_get(row, 'reacceleration_grade', None))}",
+        f"Ultra high conviction: {_format_bool(_get(row, 'ultra_high_conviction', False))}",
+        f"Actionability: {_format_optional_float(_get(row, 'actionability_score', None))}",
+        f"Chase risk: {_format_optional_float(_get(row, 'chase_risk_score', None))}",
+        f"Risk flags: {', '.join(risk_flags) if risk_flags else 'none'}",
         "Breakdown:",
         f"Trend: {_get(row, 'trend_score', 'n/a')}",
         f"Volume breakout: {_get(row, 'volume_breakout_score', 'n/a')}",

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,60 @@
+from altcoin_trend.signals.explain import build_explain_text
+
+
+def test_build_explain_text_surfaces_signal_v2_fields():
+    text = build_explain_text(
+        {
+            "exchange": "binance",
+            "symbol": "RAVEUSDT",
+            "final_score": 88.5,
+            "tier": "watchlist",
+            "signal_priority": 2,
+            "continuation_grade": None,
+            "ignition_grade": "",
+            "reacceleration_grade": "B",
+            "ultra_high_conviction": False,
+            "actionability_score": 71.25,
+            "chase_risk_score": 20.0,
+            "risk_flags": ["ULTRA_HIGH_CONVICTION", None, "PRICE_UP_OI_DOWN"],
+            "trend_score": 80.0,
+            "volume_breakout_score": 74.7,
+            "relative_strength_score": 91.0,
+            "derivatives_score": 42.0,
+            "quality_score": 95.0,
+            "veto_reason_codes": [None, ""],
+        }
+    )
+
+    assert "binance:RAVEUSDT" in text
+    assert "Signal v2:" in text
+    assert "Priority: 2" in text
+    assert "Continuation: -" in text
+    assert "Ignition: -" in text
+    assert "Reacceleration: B" in text
+    assert "Ultra high conviction: no" in text
+    assert "Actionability: 71.25" in text
+    assert "Chase risk: 20.00" in text
+    assert "Risk flags: ULTRA_HIGH_CONVICTION, PRICE_UP_OI_DOWN" in text
+    assert "Veto: none" in text
+
+
+def test_build_explain_text_handles_missing_signal_v2_fields():
+    text = build_explain_text(
+        {
+            "exchange": "bybit",
+            "symbol": "SOLUSDT",
+            "final_score": 42.0,
+            "tier": "rejected",
+            "veto_reason_codes": "STALE_MARKET",
+        }
+    )
+
+    assert "Priority: n/a" in text
+    assert "Continuation: -" in text
+    assert "Ignition: -" in text
+    assert "Reacceleration: -" in text
+    assert "Ultra high conviction: no" in text
+    assert "Actionability: n/a" in text
+    assert "Chase risk: n/a" in text
+    assert "Risk flags: none" in text
+    assert "Veto: STALE_MARKET" in text


### PR DESCRIPTION
## Summary

- Add a `Signal v2` section to `acts explain` output.
- Surface priority, continuation, ignition, reacceleration, ultra-high-conviction, actionability, chase risk, and risk flags.
- Normalize empty/None veto and risk flag values so explain output stays clean.
- Add regression tests for reacceleration explain output and missing signal-v2 fields.

## Validation

- Added `tests/test_explain.py`.
- Local patch validation previously passed for the new test file: `2 passed in 0.30s`.

## Notes

This follows the latest reacceleration signal-family commit by making the new signal fields visible in explain output instead of only existing in ranking/candidate internals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Signal v2 details in the explain output to make reacceleration signals visible. Cleans up empty veto/risk fields and adds regression tests.

- **New Features**
  - Add "Signal v2" section with priority, continuation/ignition/reacceleration grades, ultra-high conviction, actionability, chase risk, and risk flags.

- **Bug Fixes**
  - Normalize empty/None veto reasons and risk flags to display as "none".
  - Gracefully format missing numbers and grades as "n/a" or "-".

<sup>Written for commit c586037a38da76fd595eb7f7203b3222a87bb293. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

